### PR TITLE
docker-compose.yaml Bookstack für Raspberry PI

### DIFF
--- a/docker-compose_rpi-bookstack.yaml
+++ b/docker-compose_rpi-bookstack.yaml
@@ -1,0 +1,34 @@
+version: '3.3'
+
+services:
+  bookstack-db:
+    image: linuxserver/mariadb
+    container_name: bookstack-db
+    restart: always
+    volumes:
+      - /var/docker/bookstack/database:/var/lib/mysql
+    environment:
+      - TZ=Europe/Berlin
+      - PUID=1000
+      - PGID=1000
+      - MYSQL_ROOT_PASSWORD= # Setze hier ein starkes Passwort
+      - MYSQL_DATABASE=bookstack
+      - MYSQL_USER=bookstack
+      - MYSQL_PASSWORD=# Ein anderes Passwort
+    ports:
+      - 3306:3306
+
+  bookstack-app:
+    image: solidnerd/bookstack
+    container_name: bookstack-app
+    restart: always
+    volumes:
+      - /var/docker/bookstack/app/uploads:/var/www/bookstack/public/uploads
+      - /var/docker/bookstack/app/storage-uploads:/var/www/bookstack/public/storage
+    environment:
+      - DB_HOST=bookstack-db:3306
+      - DB_DATABASE=bookstack
+      - DB_USERNAME=bookstack
+      - DB_PASSWORD= # Hier das Passwort von MYSQL_PASSWORD aus dem Datenbankcontainer setzen
+    ports:
+      -  192.168.0.10:8080:80 # Ip von der die Webgui abrufbar ist


### PR DESCRIPTION
Docker-Compose.yaml Datei zur Benutzung von Bookstack auf einem Raspberry PI.
Als Datenbank wird MariaDB verwendet, da es kein offizielles MySQL Docker Image gibt, welches den Raspberry PI (armv7l)
unterstützt. Das Bockstack Image muss für armv7l Kompatibilität neu compiliert werden.

docker build -t solidnerd/bookstack github.com/solidnerd/docker-bookstack