### PR TITLE
Update README.md

### DIFF
--- a/traefik/README.md
+++ b/traefik/README.md
@@ -15,5 +15,5 @@ Traefik speichert alle notwendigen Informationen zu den Zertifikaten als JSON im
 
 ```bash
 cd config/ACME
-chmod acme.json
+chmod 600 acme.json
 ```


### PR DESCRIPTION
chmod korrigiert.
Traefik kann diese Datei nur verwenden, wenn der Root-Benutzer innerhalb des Containers einen eindeutigen Lese- und Schreibzugriff darauf hat. Nur der Eigentümer der Datei hat Lese- und Schreibrechte (chmod 600).