### PR TITLE
Update docker-compose_rpi-nextcloud.yaml

### DIFF
--- a/nextcloud/docker-compose_rpi-nextcloud.yaml
+++ b/nextcloud/docker-compose_rpi-nextcloud.yaml
@@ -6,7 +6,8 @@ services:
     container_name: nextcloud-db
     restart: always
     volumes:
-      - /var/docker/nextcloud/database:/var/lib/mysql
+      - /var/docker/nextcloud/database_var:/var/lib/mysql
+      - /var/docker/nextcloud/database_config:/config
     environment:
       - TZ=Europe/Berlin
       - PUID=1000


### PR DESCRIPTION
The image linuxserver/mariadb uses /config instead of /var/lib for persistent database data