### PR TITLE
Update docker-compose.yaml

### DIFF
--- a/traefik/docker-compose.yaml
+++ b/traefik/docker-compose.yaml
@@ -3,7 +3,7 @@ version: '3.3'
 
 services:
   traefik:
-    image: traefik:latest
+    image: traefik:1.7.6
     container_name: traefik
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
@@ -22,4 +22,4 @@ networks:
     external:
       name: traefik_proxy
   default:
-    driver: bridge
+    driver: bridge    


### PR DESCRIPTION
Mit ":latest" oder Versionen >= 2 geht es leider nicht. Die 1.7.6 funktioniert gut.