### PR TITLE
Fix ACME storage

### DIFF
--- a/traefik/config/traefik.toml
+++ b/traefik/config/traefik.toml
@@ -23,5 +23,5 @@
 [certificatesResolvers]
   [certificatesResolvers.default.acme]
     email = "mail@example.com" #Email Adresse hier anpassen
-    storage = "acme.json"
+    storage = "/etc/traefik/ACME/acme.json"
     [certificatesResolvers.default.acme.tlsChallenge]


### PR DESCRIPTION
After recreating my traefik container all certificates got lost. Therefore I attached to the container and figured out that traefik has created it's own /acme.json. This fixes the problem.

PS: I thing that you can remove  chmod 600 acme.json from the readme, because the new created acme.json has already the given rights and therefore the file should be automatically created by traefik. But I haven't tested this.