### PR TITLE
add customFrameOptionsValue: SAMEORIGIN

### DIFF
--- a/traefik/config/dynamic.yml
+++ b/traefik/config/dynamic.yml
@@ -24,6 +24,7 @@ http:
         browserXssFilter: true
         contentTypeNosniff: true
         frameDeny: true
+        customFrameOptionsValue: SAMEORIGIN
         sslRedirect: true
         #HSTS Configuration
         stsIncludeSubdomains: true


### PR DESCRIPTION
[Nextcloud 18 security-related-headers](https://docs.nextcloud.com/server/18/admin_manual/installation/harden_server.html?highlight=sameorigin#serve-security-related-headers-by-the-web-server)

[traefik customframeoptionsvalue](https://docs.traefik.io/v2.0/middlewares/headers/#customframeoptionsvalue)

Bei der Verwendung von Nextcloud 18, erhalte ich einen Fehler `Der „X-Frame-Options“-HTTP-Header ist nicht so konfiguriert, dass er „SAMEORIGIN“ entspricht. Einige Funktionen funktionieren möglicherweise nicht richtig. Daher wird empfohlen, diese Einstellung zu ändern.`