### PR TITLE
Nextcloud: "X-Frame-Options SAMEORIGIN" und "/.well-known/caldav"

### DIFF
--- a/nextcloud/docker-compose.yaml
+++ b/nextcloud/docker-compose.yaml
@@ -34,7 +34,7 @@ services:
       - "traefik.http.routers.nextcloud.rule=Host(`nextcloud.example.com`)" #Domain anpassen
       - "traefik.http.routers.nextcloud.tls=true"
       - "traefik.http.routers.nextcloud.tls.certresolver=default"
-      - "traefik.http.routers.nextcloud.middlewares=secHeaders@file"
+      - "traefik.http.routers.nextcloud.middlewares=secHeadersNextcloud@file"
       - "traefik.http.services.nextcloud.loadbalancer.server.port=80"
     networks:
       - traefik_proxy

--- a/nextcloud/docker-compose.yaml
+++ b/nextcloud/docker-compose.yaml
@@ -37,6 +37,7 @@ services:
       - "traefik.http.routers.nextcloud.middlewares=secHeadersNextcloud@file, nextcloud-dav@docker"
       - "traefik.http.services.nextcloud.loadbalancer.server.port=80"
       # Middleware nextcloud-dav ersetzt .well-known Pfad in caldav und carddav mit den korrekten Nextcloud Pfad
+      # https://docs.nextcloud.com/server/18/admin_manual/issues/general_troubleshooting.html#service-discovery-label
       - "traefik.http.middlewares.nextcloud-dav.replacepathregex.regex=^/.well-known/ca(l|rd)dav"
       - "traefik.http.middlewares.nextcloud-dav.replacepathregex.replacement=/remote.php/dav/"
     networks:

--- a/nextcloud/docker-compose.yaml
+++ b/nextcloud/docker-compose.yaml
@@ -34,8 +34,11 @@ services:
       - "traefik.http.routers.nextcloud.rule=Host(`nextcloud.example.com`)" #Domain anpassen
       - "traefik.http.routers.nextcloud.tls=true"
       - "traefik.http.routers.nextcloud.tls.certresolver=default"
-      - "traefik.http.routers.nextcloud.middlewares=secHeadersNextcloud@file"
+      - "traefik.http.routers.nextcloud.middlewares=secHeadersNextcloud@file, nextcloud-dav@docker"
       - "traefik.http.services.nextcloud.loadbalancer.server.port=80"
+      # Middleware cloud-dav replaces .well-known paths for caldav and carddav with proper nextcloud path
+      - "traefik.http.middlewares.nextcloud-dav.replacepathregex.regex=^/.well-known/ca(l|rd)dav"
+      - "traefik.http.middlewares.nextcloud-dav.replacepathregex.replacement=/remote.php/dav/"
     networks:
       - traefik_proxy
       - default

--- a/nextcloud/docker-compose.yaml
+++ b/nextcloud/docker-compose.yaml
@@ -36,7 +36,7 @@ services:
       - "traefik.http.routers.nextcloud.tls.certresolver=default"
       - "traefik.http.routers.nextcloud.middlewares=secHeadersNextcloud@file, nextcloud-dav@docker"
       - "traefik.http.services.nextcloud.loadbalancer.server.port=80"
-      # Middleware cloud-dav replaces .well-known paths for caldav and carddav with proper nextcloud path
+      # Middleware nextcloud-dav ersetzt .well-known Pfad in caldav und carddav mit den korrekten Nextcloud Pfad
       - "traefik.http.middlewares.nextcloud-dav.replacepathregex.regex=^/.well-known/ca(l|rd)dav"
       - "traefik.http.middlewares.nextcloud-dav.replacepathregex.replacement=/remote.php/dav/"
     networks:

--- a/traefik/config/dynamic.yml
+++ b/traefik/config/dynamic.yml
@@ -29,3 +29,14 @@ http:
         stsIncludeSubdomains: true
         stsPreload: true
         stsSeconds: 15768000
+    secHeadersNextcloud:
+      headers:
+        browserXssFilter: true
+        contentTypeNosniff: true
+        #frameDeny: true
+        customFrameOptionsValue: SAMEORIGIN
+        sslRedirect: true
+        #HSTS Configuration
+        stsIncludeSubdomains: true
+        stsPreload: true
+        stsSeconds: 15768000        


### PR DESCRIPTION
neuer "secHeadersNextcloud" mit dem X-Frame-Options SAMEORIGIN
Da es beim Start von Nextcloud 18 zu folgenden Fehler kommt.

> Bei der Verwendung von Nextcloud 18, erhalte ich einen Fehler `Der „X-Frame-Options“-HTTP-Header ist nicht so konfiguriert, dass er „SAMEORIGIN“ entspricht. Einige Funktionen funktionieren möglicherweise nicht richtig. Daher wird empfohlen, diese Einstellung zu ändern.