### PR TITLE
Netzwerke im Grafana Container für ProxyZugriff definiert

### DIFF
--- a/monitoring/docker-compose.yaml
+++ b/monitoring/docker-compose.yaml
@@ -60,6 +60,9 @@ services:
       - "traefik.http.routers.grafana.tls.certresolver=default"
       - "traefik.http.routers.grafana.middlewares=secHeaders@file"
       - "traefik.http.services.grafana.loadbalancer.server.port=3000"
+    networks:
+      - traefik_proxy
+      - default
 
 networks:
   traefik_proxy:


### PR DESCRIPTION
Damit der Grafana Container aus dem Internet angesprochen werden kann und mit dem Prometheus kommunizeiren kann, 
mussten die Netzwerke traefik_proxy und default bei diesem Container hinzugefügt werden.