### PR TITLE
Zeitzone vom Host im Container verwenden

### DIFF
--- a/apt-cacher-ng/docker-compose.yaml
+++ b/apt-cacher-ng/docker-compose.yaml
@@ -7,6 +7,8 @@ services:
     container_name: apt-cacher-ng
     restart: always
     volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
       - /var/docker/apt-cacher-ng/var/cache/apt-cacher-ng
     ports:
       - 3142:3142

--- a/bitwarden_rs/docker-compose.yaml
+++ b/bitwarden_rs/docker-compose.yaml
@@ -7,7 +7,9 @@ services:
     container_name: bitwarden
     restart: unless-stopped
     volumes:
-       - /var/docker/bitwarden:/data
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
+      - /var/docker/bitwarden:/data
     labels:
       - "traefik.enable=true"
       - "traefik.http.middlewares.bitwarden-https.redirectscheme.scheme=https"

--- a/bookstack/docker-compose.yaml
+++ b/bookstack/docker-compose.yaml
@@ -7,6 +7,8 @@ services:
     container_name: bookstack-db
     restart: always
     volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
       - /var/docker/bookstack/database:/var/lib/mysql
     environment:
       - MYSQL_ROOT_PASSWORD= # Setze hier ein starkes Passwort
@@ -20,6 +22,8 @@ services:
     container_name: bookstack-app
     restart: always
     volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
       - /var/docker/bookstack/app:/config
     links:
       - bookstack-db

--- a/calibre/docker-compse.yaml
+++ b/calibre/docker-compse.yaml
@@ -6,6 +6,8 @@ services:
     container_name: calibre
     restart: unless-stopped
     volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
       - /var/docker/calibre/config:/config
     environment:
       - PUID=1000
@@ -17,6 +19,8 @@ services:
     container_name: calibre-web
     restart: unless-stopped
     volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
       - /var/docker/calibre-web/config:/config
       - /var/docker/calibre/config/Calibre-Bibliothek:/books
     environment:

--- a/droneio/docker-compse.yaml
+++ b/droneio/docker-compse.yaml
@@ -7,6 +7,8 @@ services:
     container_name: droneio
     restart: unless-stopped
     volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
       - $PWD/data:/data
     environment:
       - DRONE_GITEA_SERVER=https://drone.example.com # Bitte URL anpassen
@@ -36,6 +38,8 @@ services:
     container_name: drone-runner
     restart: unless-stopped
     volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
       - DRONE_RPC_PROTO=https

--- a/freshrss/docker-compose.yaml
+++ b/freshrss/docker-compose.yaml
@@ -7,6 +7,8 @@ services:
     container_name: fressrss-db
     restart: unless-stopped
     volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
       - /var/docker/freshrss/db:/var/lib/postgresql/data
     environment:
       - POSTGRES_USER=freshrss
@@ -20,6 +22,8 @@ services:
     depends_on:
       - freshrss-db
     volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
       - /var/docker/freshrss/data:/var/www/FreshRSS/data
       - /var/docker/freshrss/extensions:/var/www/FreshRSS/extensions
     environment:

--- a/gitea/docker-compose.yaml
+++ b/gitea/docker-compose.yaml
@@ -7,6 +7,8 @@ services:
     container_name: gitea-db
     restart: unless-stopped
     volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
       - /var/docker/gitea/db:/var/lib/mysql
     environment:
       - MYSQL_ROOT_PASSWORD= # Starkes Passwort setzen
@@ -19,6 +21,8 @@ services:
     container_name: gitea-app
     restart: unless-stopped
     volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
       - /var/docker/gitea/data:/data
       - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro

--- a/guacamole/docker-compose.yaml
+++ b/guacamole/docker-compose.yaml
@@ -12,6 +12,8 @@ services:
     container_name: guacamole_mysql
     restart: unless-stopped
     volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
       - /var/docker/data/guacamole/mysql:/var/lib/mysql
     environment:
       - MYSQL_ROOT_PASSWORD= # Setze hier ein starkes Passwort

--- a/heimdall/docker-compose.yaml
+++ b/heimdall/docker-compose.yaml
@@ -7,6 +7,8 @@ services:
     container_name: heimdall
     restart: unless-stopped
     volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
       - /var/docker/heimdall/config:/config
     ports:
       - 8085:80

--- a/ilias/docker-compose.yaml
+++ b/ilias/docker-compose.yaml
@@ -8,6 +8,8 @@ services:
     depends_on:
       - ilias-db
     volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
       - /var/docker/data/ilias/html:/var/www/html/data
       - /var/docker/data/ilias/data:/var/iliasdata/ilias
     environment:
@@ -42,6 +44,8 @@ services:
     depends_on:
       - ilias-app
     volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
       - /var/docker/data/ilias/lucened:/var/lucenedata/ilias
       - /var/docker/data/ilias/html:/app/data:ro
       - /var/docker/data/ilias/data:/app/iliasdata:ro
@@ -56,6 +60,8 @@ services:
       --character-set-server=utf8
       --collation-server=utf8_general_ci
     volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
       - /var/docker/data/db:/var/lib/mysql
     environment:
       - MYSQL_DATABASE=ilias

--- a/miniflux/docker-compose.yaml
+++ b/miniflux/docker-compose.yaml
@@ -35,6 +35,8 @@ services:
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
     volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
       - /var/docker/miniflux/db:/var/lib/postgresql/data
 
 networks:

--- a/monitoring/docker-compose.yaml
+++ b/monitoring/docker-compose.yaml
@@ -7,6 +7,8 @@ services:
     container_name: mon_prometheus
     restart: unless-stopped
     volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
       - $PWD/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
     depends_on:
       - mon_node-exporter
@@ -17,6 +19,8 @@ services:
     container_name: mon_node-exporter
     restart: unless-stopped
     volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro
       - /:/rootfs:ro
@@ -32,6 +36,8 @@ services:
     container_name: mon_cadvisor
     restart: unless-stopped
     volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
       - /:/rootfs:ro
       - /var/run:/var/run:rw
       - /sys:/sys:ro
@@ -42,6 +48,8 @@ services:
     container_name: mon_grafana
     restart: unless-stopped
     volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
       - /var/docker/data/monitoring/grafana:/var/lib/grafana
     ports:
       - 3000:3000

--- a/nextcloud/docker-compose.yaml
+++ b/nextcloud/docker-compose.yaml
@@ -8,6 +8,8 @@ services:
     command: --transaction-isolation=READ-COMMITTED --log-bin=ROW
     restart: always
     volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
       - /var/docker/nextcloud/database:/var/lib/mysql
     environment:
       - MYSQL_ROOT_PASSWORD= # Datenbank Passwort wählen

--- a/nextcloud/docker-compose_rpi-nextcloud.yaml
+++ b/nextcloud/docker-compose_rpi-nextcloud.yaml
@@ -6,6 +6,8 @@ services:
     container_name: nextcloud-db
     restart: always
     volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
       - /var/docker/nextcloud/database_var:/var/lib/mysql
       - /var/docker/nextcloud/database_config:/config
     environment:
@@ -24,6 +26,8 @@ services:
   #     - nextcloud-db
   #   restart: always
   #   volumes:
+  #     - /etc/localtime:/etc/localtime:ro
+  #     - /etc/timezone:/etc/timezone:ro
   #     - /var/docker/nextcloud/backup:/db
   #   environment:
   #     - DB_DUMP_FREQ=60 # Backup jede Stunde - Angabe in Minuten

--- a/phpipam/docker-compose.yaml
+++ b/phpipam/docker-compose.yaml
@@ -7,6 +7,8 @@ services:
     container_name: phpipam-mysql
     restart: unless-stopped
     volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
       - /var/docker/data/phpipam/mysql:/var/lib/mysql
     environment:
       - MYSQL_ROOT_PASSWORD= # Starkes Passwort setzen!

--- a/pi-hole/docker-compose.yaml
+++ b/pi-hole/docker-compose.yaml
@@ -8,6 +8,8 @@ services:
       - "192.168.0.2:53:53/tcp" #IP anpassen
       - "192.168.0.2:53:53/udp" #IP anpassen
     volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
       - '/var/docker/pi-hole/etc/pihole/:/etc/pihole/'
       - '/var/docker/pi-hole/etc/dnsmasq.d/:/etc/dnsmasq.d/'
     labels:

--- a/plex/docker-compose.yaml
+++ b/plex/docker-compose.yaml
@@ -8,6 +8,8 @@ services:
     restart: always
     network: host
     volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
       - /var/docker/plex/config:/config
       - /var/docker/plex/transcode:/transcode # Den Pfad kannst du natürlich auch anpassen
       - <path>:/data # Den Pfad bitte so setzen, dass Plex an eure Medien ran kommt

--- a/portainer/docker-compose.yaml
+++ b/portainer/docker-compose.yaml
@@ -6,6 +6,8 @@ services:
     image: portainer/portainer:latest
     container_name: portainer
     volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
       - /var/run/docker.sock:/var/run/docker.sock
       - /var/docker/portainer:/data
     labels:

--- a/statping/docker-compose.yml
+++ b/statping/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     image: statping/statping:latest
     restart: always
     volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
       - /var/docker/statping/data:/app
     environment:
       DB_CONN: sqlite

--- a/tautulli/docker-compose.yaml
+++ b/tautulli/docker-compose.yaml
@@ -7,6 +7,8 @@ services:
     container_name: tautulli
     restart: unless-stopped
     volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
       - $PWD/data:/config
     environment:
       - PUID=1000

--- a/traefik/docker-compose.yaml
+++ b/traefik/docker-compose.yaml
@@ -6,9 +6,10 @@ services:
     image: traefik:latest
     container_name: traefik
     volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
       - /var/run/docker.sock:/var/run/docker.sock
       - $PWD/config:/etc/traefik
-      - /etc/localtime:/etc/localtime
     #labels:
     #  - "traefik.enable=true"
     #  - "traefik.http.routers.api.rule=Host(`traefik.example.com`) && PathPrefix(`/dashboard`)"    # Domainnamen anpassen!

--- a/wallabag/docker-compose.yaml
+++ b/wallabag/docker-compose.yaml
@@ -6,6 +6,8 @@ services:
     container_name: wallabag-app
     restart: always
     volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
       - /var/docker/wallabag/images:/var/www/wallabag/web/assets/images
       - /var/docker/wallabag/data:/var/www/wallabag/data
     depends_on:
@@ -41,6 +43,8 @@ services:
     container_name: wallabag-db
     restart: always
     volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
       - /var/docker/wallabag/data:/var/lib/mysql
     environment:
       - MYSQL_DATABASE=wallabag

--- a/watchtower/docker-compse.yaml
+++ b/watchtower/docker-compse.yaml
@@ -7,5 +7,6 @@ services:
     container_name: watchtower
     restart: unless-stopped
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      - /etc/localtime:/etc/localtime:ro
       - /etc/timezone:/etc/timezone:ro
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/wiki-js/docker-compose.yml
+++ b/wiki-js/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       driver: "none"
     restart: unless-stopped
     volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
       - db-data:/var/lib/postgresql/data
 
   wiki:

--- a/wordpress/docker-compose.yaml
+++ b/wordpress/docker-compose.yaml
@@ -7,6 +7,8 @@ services:
     container_name: wordpress-db
     restart: always
     volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
       - /var/docker/wordpress/database:/var/lib/mysql
     environment:
       - MYSQL_ROOT_PASSWORD= # Starkes Passwort setzen
@@ -20,6 +22,8 @@ services:
     container_name: wordpress-app
     restart: always
     volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
       - /var/docker/wordpress/data:/var/www/html/wp-content
     environment:
       - WORDPRESS_DB_HOST=wordpress-db:3306


### PR DESCRIPTION
Damit in dem Container die gleiche :clock1: Zeitzone wie im Host verwendet wird, 
habe ich in jede docker-compose.yaml die 2 Volume hinzugefügt.

```
volumes:
    - /etc/timezone:/etc/timezone:ro
    - /etc/localtime:/etc/localtime:ro
```