### PR TITLE
Umstellung auf wordpress-fpm

### DIFF
--- a/wordpress/default.conf
+++ b/wordpress/default.conf
@@ -1,0 +1,38 @@
+gzip on;
+gzip_comp_level 5;
+gzip_min_length 256;
+gzip_proxied any;
+gzip_vary on;
+gzip_types text/plain text/css text/xml application/json application/javascript application/xml+rss application/atom+xml image/svg+xml;
+
+server {
+  listen 0.0.0.0:80;
+  server_name 127.0.0.1;
+
+  root /var/www/html;
+  index index.php;
+
+  location / {
+    try_files $uri $uri/ /index.php?q=$uri&$args;
+  }
+
+  if (!-e $request_filename)
+  {
+    rewrite ^/(.+)$ /index.php?q=$1 last;
+  }
+
+  location ~ \.php$ {
+    fastcgi_pass wordpress-app:9000;
+    fastcgi_index index.php;
+    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+    include fastcgi_params;
+    fastcgi_param HTTPS on;
+  }
+
+  location ~* \.(js|css|png|jpg|jpeg|gif|ico|woff|woff2)$ {
+    expires max;
+    log_not_found off;
+  }
+
+  client_max_body_size 20M;
+}

--- a/wordpress/docker-compose.yaml
+++ b/wordpress/docker-compose.yaml
@@ -18,7 +18,7 @@ services:
       - MYSQL_INITDB_SKIP_TZINFO=1 # Behebt die bekannten Startprobleme 
 
   wordpress-app:
-    image: wordpress:latest
+    image: wordpress-fpm:latest
     container_name: wordpress-app
     restart: always
     volumes:
@@ -30,6 +30,20 @@ services:
       - WORDPRESS_DB_USER=wordpress
       - WORDPRESS_DB_PASSWORD= # MYSQL_PASSWORD hier einfügen
       - WORDPRESS_DB_NAME=wordpress
+    networks:
+      - default
+
+  wordpress-web:
+    image: nginx:1
+    restart: unless-stopped
+    networks:
+      - default
+      - traefik-proxy
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
+      - /var/docker/wordpress/data:/var/www/html/wp-content:ro
+      - ./default.conf:/etc/nginx/conf.d/default.conf:ro
     labels:
       - "traefik.enable=true"
       - "traefik.http.middlewares.wordpress-https.redirectscheme.scheme=https"
@@ -42,9 +56,6 @@ services:
       - "traefik.http.routers.wordpress.tls.certresolver=default"
       - "traefik.http.routers.wordpress.middlewares=secHeaders@file"
       - "traefik.http.services.wordpress.loadbalancer.server.port=80"
-    networks:
-      - default
-      - traefik_proxy
 
 networks:
   traefik_proxy:


### PR DESCRIPTION
In der Vergangenheit habe ich die Erfahrung gemacht, dass der offizielle WordPress-Container (mit Apache) gerade bei Themes und Plugins mit vielen Dateien/Requests sehr langsam wird. Das liegt wohl daran, dass alles Requests durch Apache und PHP durchgeschleift werden müssen, und nur eine bestimmte Anzahl von Workern zur Verfügung steht (das ist jetzt Vermutung).

Eine Alternative wäre, die (ebenfalls offiziellen) FPM-Versionen von WordPress zu verwenden und nginx als Webserver zu verwenden. Statische Dateien (Bilder, CSS, JS) werden direkt von nginx ausgeliefert, PHP-Seiten durch php-fpm erzeugt.

Das hat den Nachteil, dass `.htaccess`-Dateien nicht mehr funktionieren, aber den Vorteil, dass die Geschwindigkeit (zumindest in den von mir verwendeten Umgebungen) um ein Vielfaches schneller ist.

Die nginx-Konfiguration ist an die offiziellen [nginx-Vorschläge von WordPress](https://wordpress.org/support/article/nginx/) und die [Docker-Umsetzung von Bitnami](https://github.com/bitnami/bitnami-docker-wordpress-nginx/blob/master/5/debian-10/wordpress-server-block.conf) angelehnt.