### PR TITLE
Update Portainer Container auf Version 2

### DIFF
--- a/portainer/docker-compose.yaml
+++ b/portainer/docker-compose.yaml
@@ -3,7 +3,7 @@ version: '3.3'
 
 services:
   portainer:
-    image: portainer/portainer:latest
+    image: portainer/portainer-ce:latest
     container_name: portainer
     volumes:
       - /etc/localtime:/etc/localtime:ro


### PR DESCRIPTION
NOTE, This repo, portainer/portainer is the home of Portainer v1.24.x, and is now deprecated; all new releases for Portainer 2.0 will be published in portainer/portainer-ce

Quelle: https://hub.docker.com/r/portainer/portainer