### PR TITLE
globale http zu https Weiterleitung

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,4 +84,5 @@ Alphabetisch sortiert
 * Wallabag (https://www.wallabag.it/de/)
 * Watchtower (https://github.com/containrrr/watchtower)
 * Wiki.js (https://wiki.js.org)
+* WireHole (https://github.com/IAmStoxe/wirehole)
 * Wordpress (https://de.wordpress.org)

--- a/bitwarden_rs/docker-compose.yaml
+++ b/bitwarden_rs/docker-compose.yaml
@@ -12,11 +12,7 @@ services:
       - /var/docker/bitwarden:/data
     labels:
       - "traefik.enable=true"
-      - "traefik.http.middlewares.bitwarden-https.redirectscheme.scheme=https"
-      - "traefik.http.routers.bitwarden-http.entrypoints=web"
-      - "traefik.http.routers.bitwarden-http.rule=Host(`${BITWARDEN_URL}`)"
-      - "traefik.http.routers.bitwarden-http.middlewares=bitwarden-https@docker"
-      - "traefik.http.routers.bitwarden.entrypoints=web-secure"
+      - "traefik.http.routers.bitwarden.entrypoints=websecure"
       - "traefik.http.routers.bitwarden.rule=Host(`${BITWARDEN_URL}`)"
       - "traefik.http.routers.bitwarden.tls=true"
       - "traefik.http.routers.bitwarden.tls.certresolver=default"

--- a/bookstack/docker-compose.yaml
+++ b/bookstack/docker-compose.yaml
@@ -35,11 +35,7 @@ services:
       - APP_URL=https://${BOOKSTACK_URL}  # Zeile auskommentieren, wenn kein Traefik verwendet wird!
     labels:
       - "traefik.enable=true"
-      - "traefik.http.middlewares.bookstack-https.redirectscheme.scheme=https"
-      - "traefik.http.routers.bookstack-http.entrypoints=web"
-      - "traefik.http.routers.bookstack-http.rule=Host(`${BOOKSTACK_URL}`)"
-      - "traefik.http.routers.bookstack-http.middlewares=bookstack-https@docker"
-      - "traefik.http.routers.bookstack.entrypoints=web-secure"
+      - "traefik.http.routers.bookstack.entrypoints=websecure"
       - "traefik.http.routers.bookstack.rule=Host(`${BOOKSTACK_URL}`)"
       - "traefik.http.routers.bookstack.tls=true"
       - "traefik.http.routers.bookstack.tls.certresolver=default"

--- a/calibre/docker-compose.yaml
+++ b/calibre/docker-compose.yaml
@@ -32,11 +32,7 @@ services:
       - calibre
     labels:
       - "traefik.enable=true"
-      - "traefik.http.middlewares.calibre-https.redirectscheme.scheme=https"
-      - "traefik.http.routers.calibre-http.entrypoints=web"
-      - "traefik.http.routers.calibre-http.rule=Host(`${CALIBRE_URL}`)"
-      - "traefik.http.routers.calibre-http.middlewares=calibre-https@docker"
-      - "traefik.http.routers.calibre.entrypoints=web-secure"
+      - "traefik.http.routers.calibre.entrypoints=websecure"
       - "traefik.http.routers.calibre.rule=Host(`${CALIBRE_URL}`)"
       - "traefik.http.routers.calibre.tls=true"
       - "traefik.http.routers.calibre.tls.certresolver=default"

--- a/calibre/docker-compose.yaml
+++ b/calibre/docker-compose.yaml
@@ -12,7 +12,6 @@ services:
     environment:
       - PUID=1000
       - PGID=1000
-      - TZ=Europe/Berlin
 
   calibre-web:
     image: linuxserver/calibre-web
@@ -26,7 +25,6 @@ services:
     environment:
       - PUID=1000
       - PGID=1000
-      - TZ=Europe/Berlin
       - DOCKER_MODS=linuxserver/calibre-web:calibre
     depends_on:
       - calibre

--- a/droneio/docker-compse.yaml
+++ b/droneio/docker-compse.yaml
@@ -9,7 +9,7 @@ services:
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - /etc/timezone:/etc/timezone:ro
-      - $PWD/data:/data
+      - /var/docker/droneio-data:/data
     environment:
       - DRONE_GITEA_SERVER=https://drone.example.com  # Bitte URL anpassen
       - DRONE_GITEA_CLIENT_ID=  # GITEA Client ID

--- a/droneio/docker-compse.yaml
+++ b/droneio/docker-compse.yaml
@@ -19,11 +19,7 @@ services:
       - DRONE_SERVER_PROTO=https
     labels:
       - "traefik.enable=true"
-      - "traefik.http.middlewares.drone-https.redirectscheme.scheme=https"
-      - "traefik.http.routers.drone-http.entrypoints=web"
-      - "traefik.http.routers.drone-http.rule=Host(`drone.example.com`)"  # Domain anpassen
-      - "traefik.http.routers.drone-http.middlewares=drone-https@docker"
-      - "traefik.http.routers.drone.entrypoints=web-secure"
+      - "traefik.http.routers.drone.entrypoints=websecure"
       - "traefik.http.routers.drone.rule=Host(`drone.example.com`)"  # Domain anpassen
       - "traefik.http.routers.drone.tls=true"
       - "traefik.http.routers.drone.tls.certresolver=default"

--- a/freescout/docker-compose.yaml
+++ b/freescout/docker-compose.yaml
@@ -25,11 +25,7 @@ services:
       - TIMEZONE=Europe/Berlin
     labels:
       - "traefik.enable=true"
-      - "traefik.http.middlewares.freescout-https.redirectscheme.scheme=https"
-      - "traefik.http.routers.freescout-http.entrypoints=web"
-      - "traefik.http.routers.freescout-http.rule=Host(`${FREESCOUT_URL}`)"
-      - "traefik.http.routers.freescout-http.middlewares=freescout-https@docker"
-      - "traefik.http.routers.freescout.entrypoints=web-secure"
+      - "traefik.http.routers.freescout.entrypoints=websecure"
       - "traefik.http.routers.freescout.rule=Host(`${FREESCOUT_URL}`)"
       - "traefik.http.routers.freescout.tls=true"
       - "traefik.http.routers.freescout.tls.certresolver=default"

--- a/freshrss/docker-compose.yaml
+++ b/freshrss/docker-compose.yaml
@@ -31,11 +31,7 @@ services:
       - TZ=Europe/Berlin
     labels:
       - "traefik.enable=true"
-      - "traefik.http.middlewares.freshrss-https.redirectscheme.scheme=https"
-      - "traefik.http.routers.freshrss-http.entrypoints=web"
-      - "traefik.http.routers.freshrss-http.rule=Host(`${FRESHRSS_URL`)"  # Domain anpassen
-      - "traefik.http.routers.freshrss-http.middlewares=freshrss-https@docker"
-      - "traefik.http.routers.freshrss.entrypoints=web-secure"
+      - "traefik.http.routers.freshrss.entrypoints=websecure"
       - "traefik.http.routers.freshrss.rule=Host(`${FRESHRSS_URL`)"  # Domain anpassen
       - "traefik.http.routers.freshrss.tls=true"
       - "traefik.http.routers.freshrss.tls.certresolver=default"

--- a/freshrss/docker-compose.yaml
+++ b/freshrss/docker-compose.yaml
@@ -28,7 +28,6 @@ services:
       - /var/docker/freshrss/extensions:/var/www/FreshRSS/extensions
     environment:
       - CRON_MIN=*/20
-      - TZ=Europe/Berlin
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.freshrss.entrypoints=websecure"

--- a/gitea/docker-compose.yaml
+++ b/gitea/docker-compose.yaml
@@ -34,11 +34,7 @@ services:
       - DB_PASSWD=${MYSQL_PASSWORD}
     labels:
       - "traefik.enable=true"
-      - "traefik.http.middlewares.gitea-https.redirectscheme.scheme=https"
-      - "traefik.http.routers.gitea-http.entrypoints=web"
-      - "traefik.http.routers.gitea-http.rule=Host(`${GITEA_URL}`)"
-      - "traefik.http.routers.gitea-http.middlewares=gitea-https@docker"
-      - "traefik.http.routers.gitea.entrypoints=web-secure"
+      - "traefik.http.routers.gitea.entrypoints=websecure"
       - "traefik.http.routers.gitea.rule=Host(`${GITEA_URL}`)"
       - "traefik.http.routers.gitea.tls=true"
       - "traefik.http.routers.gitea.tls.certresolver=default"

--- a/guacamole/docker-compose.yaml
+++ b/guacamole/docker-compose.yaml
@@ -40,11 +40,7 @@ services:
       - guacamole_mysql
     labels:
       - "traefik.enable=true"
-      - "traefik.http.middlewares.guacamole-https.redirectscheme.scheme=https"
-      - "traefik.http.routers.guacamole-http.entrypoints=web"
-      - "traefik.http.routers.guacamole-http.rule=Host(`guacamole.example.com`)"  # Domain anpassen
-      - "traefik.http.routers.guacamole-http.middlewares=guacamole-https@docker"
-      - "traefik.http.routers.guacamole.entrypoints=web-secure"
+      - "traefik.http.routers.guacamole.entrypoints=websecure"
       - "traefik.http.routers.guacamole.rule=Host(`guacamole.example.com`)"  # Domain anpassen
       - "traefik.http.routers.guacamole.tls=true"
       - "traefik.http.routers.guacamole.tls.certresolver=default"

--- a/heimdall/docker-compose.yaml
+++ b/heimdall/docker-compose.yaml
@@ -17,11 +17,7 @@ services:
       - PUID=1000
     labels:
       - "traefik.enable=true"
-      - "traefik.http.middlewares.heimdall-https.redirectscheme.scheme=https"
-      - "traefik.http.routers.heimdall-http.entrypoints=web"
-      - "traefik.http.routers.heimdall-http.rule=Host(`heimdall.example.com`)"  # Domain anpassen
-      - "traefik.http.routers.heimdall-http.middlewares=heimdall-https@docker"
-      - "traefik.http.routers.heimdall.entrypoints=web-secure"
+      - "traefik.http.routers.heimdall.entrypoints=websecure"
       - "traefik.http.routers.heimdall.rule=Host(`heimdall.example.com`)"  # Domain anpassen
       - "traefik.http.routers.heimdall.tls=true"
       - "traefik.http.routers.heimdall.tls.certresolver=default"

--- a/ilias/docker-compose.yaml
+++ b/ilias/docker-compose.yaml
@@ -40,11 +40,7 @@ services:
       - ILIAS_CLIENT_NAME=default
     labels:
       - "traefik.enable=true"
-      - "traefik.http.middlewares.ilias-https.redirectscheme.scheme=https"
-      - "traefik.http.routers.ilias-http.entrypoints=web"
-      - "traefik.http.routers.ilias-http.rule=Host(`${ILIAS_URL}`)"  # Domain anpassen
-      - "traefik.http.routers.ilias-http.middlewares=ilias-https@docker"
-      - "traefik.http.routers.ilias.entrypoints=web-secure"
+      - "traefik.http.routers.ilias.entrypoints=websecure"
       - "traefik.http.routers.ilias.rule=Host(`${ILIAS_URL}`)"  # Domain anpassen
       - "traefik.http.routers.ilias.tls=true"
       - "traefik.http.routers.ilias.tls.certresolver=default"

--- a/influxdb/docker-compose.yaml
+++ b/influxdb/docker-compose.yaml
@@ -7,6 +7,6 @@ services:
     container_name: influxdb
     restart: unless-stopped
     volumes:
-      - $PWD:/var/lib/influxdb
+      - /var/docker/influxdb:/var/lib/influxdb
     ports:
       - 8086:8086

--- a/matomo/docker-compse.yaml
+++ b/matomo/docker-compse.yaml
@@ -36,11 +36,7 @@ services:
       - traefik_proxy
     labels:
       - "traefik.enable=true"
-      - "traefik.http.middlewares.matomo-https.redirectscheme.scheme=https"
-      - "traefik.http.routers.matomo-http.entrypoints=web"
-      - "traefik.http.routers.matomo-http.rule=Host(`${MATOMO_URL}`)"
-      - "traefik.http.routers.matomo-http.middlewares=matomo-https@docker"
-      - "traefik.http.routers.matomo.entrypoints=web-secure"
+      - "traefik.http.routers.matomo.entrypoints=websecure"
       - "traefik.http.routers.matomo.rule=Host(`${MATOMO_URL}`)"
       - "traefik.http.routers.matomo.tls=true"
       - "traefik.http.routers.matomo.tls.certresolver=default"

--- a/miniflux/docker-compose.yaml
+++ b/miniflux/docker-compose.yaml
@@ -15,11 +15,7 @@ services:
       - ADMIN_PASSWORD=${ADMIN_PASSWORD}
     labels:
       - "traefik.enable=true"
-      - "traefik.http.middlewares.miniflux-https.redirectscheme.scheme=https"
-      - "traefik.http.routers.miniflux-http.entrypoints=web"
-      - "traefik.http.routers.miniflux-http.rule=Host(`${EXTERNAL_URL}`)"
-      - "traefik.http.routers.miniflux-http.middlewares=miniflux-https@docker"
-      - "traefik.http.routers.miniflux.entrypoints=web-secure"
+      - "traefik.http.routers.miniflux.entrypoints=websecure"
       - "traefik.http.routers.miniflux.rule=Host(`${EXTERNAL_URL}`)"
       - "traefik.http.routers.miniflux.tls=true"
       - "traefik.http.routers.miniflux.tls.certresolver=default"

--- a/monitoring/docker-compose.yaml
+++ b/monitoring/docker-compose.yaml
@@ -58,11 +58,7 @@ services:
       - mon_prometheus
     labels:
       - "traefik.enable=true"
-      - "traefik.http.middlewares.grafana-https.redirectscheme.scheme=https"
-      - "traefik.http.routers.grafana-http.entrypoints=web"
-      - "traefik.http.routers.grafana-http.rule=Host(`grafana.example.com`)"  # Domain anpassen
-      - "traefik.http.routers.grafana-http.middlewares=grafana-https@docker"
-      - "traefik.http.routers.grafana.entrypoints=web-secure"
+      - "traefik.http.routers.grafana.entrypoints=websecure"
       - "traefik.http.routers.grafana.rule=Host(`grafana.example.com`)"  # Domain anpassen
       - "traefik.http.routers.grafana.tls=true"
       - "traefik.http.routers.grafana.tls.certresolver=default"

--- a/nextcloud/docker-compose.yaml
+++ b/nextcloud/docker-compose.yaml
@@ -44,11 +44,7 @@ services:
       - nextcloud-db
     labels:
       - "traefik.enable=true"
-      - "traefik.http.middlewares.nextcloud-https.redirectscheme.scheme=https"
-      - "traefik.http.routers.nextcloud-http.entrypoints=web"
-      - "traefik.http.routers.nextcloud-http.rule=Host(`${NEXTCLOUD_URL}`)"
-      - "traefik.http.routers.nextcloud-http.middlewares=nextcloud-https@docker"
-      - "traefik.http.routers.nextcloud.entrypoints=web-secure"
+      - "traefik.http.routers.nextcloud.entrypoints=websecure"
       - "traefik.http.routers.nextcloud.rule=Host(`${NEXTCLOUD_URL}`)"
       - "traefik.http.routers.nextcloud.tls=true"
       - "traefik.http.routers.nextcloud.tls.certresolver=default"

--- a/nextcloud/docker-compose_rpi-nextcloud.yaml
+++ b/nextcloud/docker-compose_rpi-nextcloud.yaml
@@ -30,11 +30,7 @@ services:
       - nextcloud-db
     labels:
       - "traefik.enable=true"
-      - "traefik.http.middlewares.nextcloud-https.redirectscheme.scheme=https"
-      - "traefik.http.routers.nextcloud-http.entrypoints=web"
-      - "traefik.http.routers.nextcloud-http.rule=Host(`${NEXTCLOUD_URL}`)"
-      - "traefik.http.routers.nextcloud-http.middlewares=nextcloud-https@docker"
-      - "traefik.http.routers.nextcloud.entrypoints=web-secure"
+      - "traefik.http.routers.nextcloud.entrypoints=websecure"
       - "traefik.http.routers.nextcloud.rule=Host(`${NEXTCLOUD_URL}`)"
       - "traefik.http.routers.nextcloud.tls=true"
       - "traefik.http.routers.nextcloud.tls.certresolver=default"

--- a/nextcloud/docker-compose_rpi-nextcloud.yaml
+++ b/nextcloud/docker-compose_rpi-nextcloud.yaml
@@ -12,7 +12,6 @@ services:
       - /var/docker/nextcloud/database_var:/var/lib/mysql
       - /var/docker/nextcloud/database_config:/config
     environment:
-      - TZ=Europe/Berlin
       - PUID=1000
       - PGID=1000
       - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}

--- a/phpipam/docker-compose.yaml
+++ b/phpipam/docker-compose.yaml
@@ -29,11 +29,7 @@ services:
       - phpipam-mysql
     labels:
       - "traefik.enable=true"
-      - "traefik.http.middlewares.phpipam-https.redirectscheme.scheme=https"
-      - "traefik.http.routers.phpipam-http.entrypoints=web"
-      - "traefik.http.routers.phpipam-http.rule=Host(`${PHPIPAM_URL}`)"
-      - "traefik.http.routers.phpipam-http.middlewares=phpipam-https@docker"
-      - "traefik.http.routers.phpipam.entrypoints=web-secure"
+      - "traefik.http.routers.phpipam.entrypoints=websecure"
       - "traefik.http.routers.phpipam.rule=Host(`${PHPIPAM_URL}`)"
       - "traefik.http.routers.phpipam.tls=true"
       - "traefik.http.routers.phpipam.tls.certresolver=default"

--- a/pi-hole/docker-compose.yaml
+++ b/pi-hole/docker-compose.yaml
@@ -25,7 +25,6 @@ services:
       - "traefik.http.middlewares.pi-hole-replacepathregex.replacepathregex.replacement=/admin/$$1"
       - "traefik.http.services.pi-hole.loadbalancer.server.port=80"
     environment:
-      TZ: 'Europe/Berlin'
       DNS1: '192.168.0.1'  # IP des bisherigen DNS Server eintragen (z.B. der Router). Dieser wird von dnsmasq genutzt um Anfragen weiterzuleiten
       DNS2: 'no'
       ServerIP: '192.168.0.2'  # IP anpassen

--- a/pi-hole/docker-compose.yaml
+++ b/pi-hole/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
       - '/var/docker/pi-hole/etc/dnsmasq.d/:/etc/dnsmasq.d/'
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.pi-hole.entrypoints=web-secure"
+      - "traefik.http.routers.pi-hole.entrypoints=websecure"
       - "traefik.http.routers.pi-hole.rule=Host(`host.example.com`) && PathPrefix(`/pi-hole`)"  # Domain anpassen
       - "traefik.http.routers.pi-hole.tls=true"
       - "traefik.http.routers.pi-hole.tls.certresolver=default"

--- a/plex/docker-compose.yaml
+++ b/plex/docker-compose.yaml
@@ -14,5 +14,4 @@ services:
       - /var/docker/plex/transcode:/transcode  # Den Pfad kannst du natürlich auch anpassen
       - <path>:/data  # Den Pfad bitte so setzen, dass Plex an eure Medien ran kommt
     environment:
-      - TZ=EUROPE/BERLIN
       - PLEX_CLAIM=<token>  # Den Token hier einfügen (siehe README)

--- a/portainer/docker-compose.yaml
+++ b/portainer/docker-compose.yaml
@@ -12,11 +12,7 @@ services:
       - /var/docker/portainer:/data
     labels:
       - "traefik.enable=true"
-      - "traefik.http.middlewares.portainer-https.redirectscheme.scheme=https"
-      - "traefik.http.routers.portainer-http.entrypoints=web"
-      - "traefik.http.routers.portainer-http.rule=Host(`${PORTAINER_URL}`)"
-      - "traefik.http.routers.portainer-http.middlewares=portainer-https@docker"
-      - "traefik.http.routers.portainer.entrypoints=web-secure"
+      - "traefik.http.routers.portainer.entrypoints=websecure"
       - "traefik.http.routers.portainer.rule=Host(`${PORTAINER_URL}`)"
       - "traefik.http.routers.portainer.tls=true"
       - "traefik.http.routers.portainer.tls.certresolver=default"

--- a/recipes/docker-compose.yaml
+++ b/recipes/docker-compose.yaml
@@ -44,11 +44,7 @@ services:
       - ./mediafiles:/media
     labels:
       - "traefik.enable=true"
-      - "traefik.http.middlewares.recipes-https.redirectscheme.scheme=https"
-      - "traefik.http.routers.recipes-http.entrypoints=web"
-      - "traefik.http.routers.recipes-http.rule=Host(`${RECIPES_URL}`)"
-      - "traefik.http.routers.recipes-http.middlewares=recipes-https@docker"
-      - "traefik.http.routers.recipes.entrypoints=web-secure"
+      - "traefik.http.routers.recipes.entrypoints=websecure"
       - "traefik.http.routers.recipes.rule=Host(`${RECIPES_URL}`)"
       - "traefik.http.routers.recipes.tls=true"
       - "traefik.http.routers.recipes.tls.certresolver=default"

--- a/redmine/docker-compose.yaml
+++ b/redmine/docker-compose.yaml
@@ -22,11 +22,7 @@ services:
       - /var/docker/redmine/app:/usr/src/redmine/files
     labels:
       - "traefik.enable=true"
-      - "traefik.http.middlewares.redmine-https.redirectscheme.scheme=https"
-      - "traefik.http.routers.redmine-http.entrypoints=web"
-      - "traefik.http.routers.redmine-http.rule=Host(`redmine.example.com`)"  # Domain anpassen
-      - "traefik.http.routers.redmine-http.middlewares=redmine-https@docker"
-      - "traefik.http.routers.redmine.entrypoints=web-secure"
+      - "traefik.http.routers.redmine.entrypoints=websecure"
       - "traefik.http.routers.redmine.rule=Host(`redmine.example.com`)"  # Domain anpassen
       - "traefik.http.routers.redmine.tls=true"
       - "traefik.http.routers.redmine.tls.certresolver=default"

--- a/statping/docker-compose.yml
+++ b/statping/docker-compose.yml
@@ -14,11 +14,7 @@ services:
       DB_CONN: sqlite
     labels:
       - "traefik.enable=true"
-      - "traefik.http.middlewares.statping-https.redirectscheme.scheme=https"
-      - "traefik.http.routers.statping-http.entrypoints=web"
-      - "traefik.http.routers.statping-http.rule=Host(`${EXTERNAL_URL}`)"
-      - "traefik.http.routers.statping-http.middlewares=statping-https@docker"
-      - "traefik.http.routers.statping.entrypoints=web-secure"
+      - "traefik.http.routers.statping.entrypoints=websecure"
       - "traefik.http.routers.statping.rule=Host(`${EXTERNAL_URL}`)"
       - "traefik.http.routers.statping.tls=true"
       - "traefik.http.routers.statping.tls.certresolver=default"

--- a/tautulli/docker-compose.yaml
+++ b/tautulli/docker-compose.yaml
@@ -13,7 +13,6 @@ services:
     environment:
       - PUID=1000
       - PGID=1000
-      - TZ=Europe/London
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.tautulli.entrypoints=websecure"

--- a/tautulli/docker-compose.yaml
+++ b/tautulli/docker-compose.yaml
@@ -16,11 +16,7 @@ services:
       - TZ=Europe/London
     labels:
       - "traefik.enable=true"
-      - "traefik.http.middlewares.tautulli-https.redirectscheme.scheme=https"
-      - "traefik.http.routers.tautulli-http.entrypoints=web"
-      - "traefik.http.routers.tautulli-http.rule=Host(`${TAUTULLI_URL}`)"
-      - "traefik.http.routers.tautulli-http.middlewares=tautulli-https@docker"
-      - "traefik.http.routers.tautulli.entrypoints=web-secure"
+      - "traefik.http.routers.tautulli.entrypoints=websecure"
       - "traefik.http.routers.tautulli.rule=Host(`${TAUTULLI_URL}`)"
       - "traefik.http.routers.tautulli.tls=true"
       - "traefik.http.routers.tautulli.tls.certresolver=default"

--- a/traefik/config/dynamic.yml
+++ b/traefik/config/dynamic.yml
@@ -35,7 +35,7 @@ http:
 #   routers:
 #     router-1: # Tausche den Namen gegen etwas sprechendes aus
 #       entryPoints:
-#         - web-secure
+#         - websecure
 #       rule: "Host(`example.com`)"
 #       service: "service-1" # Den Namen am besten ähnlich zu dem oben setzen
 #       tls:

--- a/traefik/config/traefik.toml
+++ b/traefik/config/traefik.toml
@@ -12,11 +12,18 @@
 [api]
   dashboard = true
 
-[entryPoints]
-  [entryPoints.web]
-    address = ":80"
-  [entryPoints.web-secure]
-    address = ":443"
+# https://doc.traefik.io/traefik/routing/entrypoints/#redirection
+[entryPoints.web]
+  address = ":80"
+
+  [entryPoints.web.http]
+    [entryPoints.web.http.redirections]
+      [entryPoints.web.http.redirections.entryPoint]
+        to = "websecure"
+        scheme = "https"
+
+[entryPoints.websecure]
+  address = ":443"
 
 [certificatesResolvers]
   [certificatesResolvers.default.acme]

--- a/traefik/docker-compose.yaml
+++ b/traefik/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
     # labels:
     #  - "traefik.enable=true"
     #  - "traefik.http.routers.traefik.rule=Host(`traefik.example.com`) && (PathPrefix(`/api`) || PathPrefix(`/dashboard`))"
-    #  - "traefik.http.routers.traefik.entrypoints=web-secure"
+    #  - "traefik.http.routers.traefik.entrypoints=websecure"
     #  - "traefik.http.routers.traefik.tls.certresolver=default"
     #  - "traefik.http.routers.traefik.service=api@internal"
     #  - "traefik.http.routers.traefik.middlewares=auth@docker"

--- a/wallabag/docker-compose.yaml
+++ b/wallabag/docker-compose.yaml
@@ -25,11 +25,7 @@ services:
       - SYMFONY__ENV__FOSUSER_CONFIRMATION=false
     labels:
       - "traefik.enable=true"
-      - "traefik.http.middlewares.wallabag-https.redirectscheme.scheme=https"
-      - "traefik.http.routers.wallabag-http.entrypoints=web"
-      - "traefik.http.routers.wallabag-http.rule=Host(`${WALLABAG_URL}`)"
-      - "traefik.http.routers.wallabag-http.middlewares=wallabag-https@docker"
-      - "traefik.http.routers.wallabag.entrypoints=web-secure"
+      - "traefik.http.routers.wallabag.entrypoints=websecure"
       - "traefik.http.routers.wallabag.rule=Host(`${WALLABAG_URL}`)"
       - "traefik.http.routers.wallabag.tls=true"
       - "traefik.http.routers.wallabag.tls.certresolver=default"

--- a/wiki-js/docker-compose.yml
+++ b/wiki-js/docker-compose.yml
@@ -32,11 +32,7 @@ services:
       - DB_NAME=wiki
     labels:
       - "traefik.enable=true"
-      - "traefik.http.middlewares.wikijs-https.redirectscheme.scheme=https"
-      - "traefik.http.routers.wikijs-http.entrypoints=web"
-      - "traefik.http.routers.wikijs-http.rule=Host(`${WIKIJS_URL}`)"
-      - "traefik.http.routers.wikijs-http.middlewares=wikijs-https@docker"
-      - "traefik.http.routers.wikijs.entrypoints=web-secure"
+      - "traefik.http.routers.wikijs.entrypoints=websecure"
       - "traefik.http.routers.wikijs.rule=Host(`${WIKIJS_URL}`)"
       - "traefik.http.routers.wikijs.tls=true"
       - "traefik.http.routers.wikijs.tls.certresolver=default"

--- a/wirehole/.env
+++ b/wirehole/.env
@@ -1,0 +1,1 @@
+WIREHOLE_URL=example.com

--- a/wirehole/README.md
+++ b/wirehole/README.md
@@ -1,0 +1,22 @@
+## Wirehole (Wireguard, Pi-Hole und unbound)
+
+Hiermit kann man eine VPN Verbindung mit Wireguard aufbauen, und zB. nur DNS Anfragen über Pi-Hole / unbound über die VPN Verbindung leiten. Dies hat den Vorteil, dass nur ein Bruchteil der Daten über den heimischen Internet-Anschluss geleitet werden. Weiterhin werden die DNS Anfragen über unbound (DNS-Resolver) zwischengespeichert.
+
+Vorteile von Pi-Hole mit unbound sind hier zu finden [Pi-Hole unbound](https://docs.pi-hole.net/guides/dns/unbound/)
+
+Vielen Dank an | Many Thanks to:
+
+* [wirehole @IAmStoxe](https://github.com/IAmStoxe/wirehole)  
+* [@Pi-Hole](https://github.com/pi-hole/docker-pi-hole)  
+* [unbound @MatthewVance](https://github.com/MatthewVance/unbound-docker)
+
+### Vorbereitungen:
+
+1. Router-Port-Forwarding: 51820/udp [extern/intern auf docker-homelab Host]
+2. docker-compose.yaml
+   * Service > wireguard  
+            - `SERVERURL` entweder über das Script `bash install.sh` die Domain anpassen, oder manuell in der `.env` deine DynDNS Domain eintragen  
+            - `PEERS=3` # Wie viele Peers werden benötigt (Clients) [Name (getrennt mit Komma) oder Anzahl]  
+            - `ALLOWEDIPS` # bei Bedarf anpassen, default 10.9.0.0/24 == nur DNS Anfragen über VPN
+   * Service > pihole (optional)      
+            -  `53:53/tcp` & `53:53/udp` einblenden, wenn pihole auch als lokaler DNS Server verwendet werden soll

--- a/wirehole/docker-compose.yaml
+++ b/wirehole/docker-compose.yaml
@@ -1,0 +1,94 @@
+version: "3"
+
+networks:
+  private_network:
+    ipam:
+      driver: default
+      config:
+        - subnet: 10.9.0.0/24
+
+services:
+  unbound:
+    image: "mvance/unbound:latest"
+    container_name: wirehole-unbound
+    restart: unless-stopped
+    hostname: "unbound"
+    volumes:
+      - "./unbound:/opt/unbound/etc/unbound/"
+      - "/etc/localtime:/etc/localtime:ro"
+      - "/etc/timezone:/etc/timezone:ro"
+    networks:
+      private_network:
+        ipv4_address: 10.9.0.200
+
+  wireguard:
+    depends_on: [unbound, pihole]
+    image: linuxserver/wireguard
+    container_name: wirehole-wireguard
+    cap_add:
+      - NET_ADMIN
+      - SYS_MODULE
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - SERVERPORT=51820
+      - SERVERURL=wg.${WIREHOLE_URL} # Wirehole DynDNS URL
+      - PEERS=3 # Wie viele Peers werden benötigt (Clients) [Name (getrennt mit Komma) oder Anzahl]
+      - PEERDNS=10.9.0.100 # Link to pihole
+      - INTERNAL_SUBNET=10.6.0.0
+      # - ALLOWEDIPS=0.0.0.0/0 # kompletter Netzverkehr über VPN
+      - ALLOWEDIPS=10.9.0.0/24 # nur DNS Anfragen über VPN  ## FASTER
+    #   - ALLOWEDIPS=10.9.0.0/24,192.168.178.0/32 # nur DNS Anfragen über VPN (inkl. Zugriff auf lokale Hosts)
+    volumes:
+      - /var/docker/wirehole/wireguard:/config
+      - /lib/modules:/lib/modules
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
+    ports:
+      - "51820:51820/udp"
+    dns:
+      - 10.9.0.100 # Points to pihole
+      - 10.9.0.200 # Points to unbound
+    sysctls:
+      - net.ipv4.conf.all.src_valid_mark=1
+    restart: unless-stopped
+    networks:
+      traefik_proxy:
+      private_network:
+        ipv4_address: 10.9.0.3
+    # healthcheck:
+    #   test: ["CMD", "curl", "--interface", "wg0", "-o", "/dev/null", "-m", "3", "-s", "https://1.1.1.1/dns-query?ct=application/dns-json&name=www.google.com&type=AAAA"]
+    #   interval: 1m30s
+    #   timeout: 10s
+    #   retries: 3        
+
+  pihole:
+    depends_on: [unbound]
+    container_name: wirehole-pihole
+    image: pihole/pihole:latest
+    restart: unless-stopped
+    hostname: wirehole-pihole
+    dns:
+      - 127.0.0.1
+      - 10.9.0.200 # Points to unbound
+    environment:
+      WEBPASSWORD: "" # Blank password - Can be whatever you want.
+      ServerIP: 10.1.0.100 # Internal IP of pihole
+      DNS1: 10.9.0.200 # Unbound IP
+      DNS2: 10.9.0.200 # If we don't specify two, it will auto pick google.
+    volumes:
+      - "/var/docker/wirehole/etc-pihole/:/etc/pihole/"
+      - "/var/docker/wirehole/etc-dnsmasq.d/:/etc/dnsmasq.d/"
+      - "/etc/localtime:/etc/localtime:ro"
+      - "/etc/timezone:/etc/timezone:ro"
+    # Recommended but not required (DHCP needs NET_ADMIN)
+    #   https://github.com/wirehole-pihole/docker-wirehole-pihole#note-on-capabilities
+    cap_add:
+      - NET_ADMIN
+    ports: 
+      - 890:80/tcp # pihole Admin GUI 
+      # - 53:53/tcp # Port freigeben, wenn Pihole auch lokal DNS Anfragen verwendet werden soll
+      # - 53:53/udp # Port freigeben, wenn Pihole auch lokal DNS Anfragen verwendet werden soll
+    networks:
+      private_network:
+        ipv4_address: 10.9.0.100

--- a/wirehole/docker-compose.yaml
+++ b/wirehole/docker-compose.yaml
@@ -1,4 +1,5 @@
-version: "3"
+---
+  version: "3"
 
 networks:
   private_network:
@@ -32,13 +33,13 @@ services:
       - PUID=1000
       - PGID=1000
       - SERVERPORT=51820
-      - SERVERURL=wg.${WIREHOLE_URL} # Wirehole DynDNS URL
-      - PEERS=3 # Wie viele Peers werden benötigt (Clients) [Name (getrennt mit Komma) oder Anzahl]
-      - PEERDNS=10.9.0.100 # Link to pihole
+      - SERVERURL=wg.${WIREHOLE_URL}  # Wirehole DynDNS URL
+      - PEERS=3  # Wie viele Peers werden benötigt (Clients) [Name (getrennt mit Komma) oder Anzahl]
+      - PEERDNS=10.9.0.100  # Link to pihole
       - INTERNAL_SUBNET=10.6.0.0
-      # - ALLOWEDIPS=0.0.0.0/0 # kompletter Netzverkehr über VPN
-      - ALLOWEDIPS=10.9.0.0/24 # nur DNS Anfragen über VPN  ## FASTER
-    #   - ALLOWEDIPS=10.9.0.0/24,192.168.178.0/32 # nur DNS Anfragen über VPN (inkl. Zugriff auf lokale Hosts)
+      # - ALLOWEDIPS=0.0.0.0/0  # kompletter Netzverkehr über VPN
+      - ALLOWEDIPS=10.9.0.0/24  # nur DNS Anfragen über VPN  ## FASTER
+    #   - ALLOWEDIPS=10.9.0.0/24,192.168.178.0/32  # nur DNS Anfragen über VPN (inkl. Zugriff auf lokale Hosts)
     volumes:
       - /var/docker/wirehole/wireguard:/config
       - /lib/modules:/lib/modules
@@ -47,8 +48,8 @@ services:
     ports:
       - "51820:51820/udp"
     dns:
-      - 10.9.0.100 # Points to pihole
-      - 10.9.0.200 # Points to unbound
+      - 10.9.0.100  # Points to pihole
+      - 10.9.0.200  # Points to unbound
     sysctls:
       - net.ipv4.conf.all.src_valid_mark=1
     restart: unless-stopped
@@ -60,7 +61,7 @@ services:
     #   test: ["CMD", "curl", "--interface", "wg0", "-o", "/dev/null", "-m", "3", "-s", "https://1.1.1.1/dns-query?ct=application/dns-json&name=www.google.com&type=AAAA"]
     #   interval: 1m30s
     #   timeout: 10s
-    #   retries: 3        
+    #   retries: 3
 
   pihole:
     depends_on: [unbound]
@@ -70,12 +71,12 @@ services:
     hostname: wirehole-pihole
     dns:
       - 127.0.0.1
-      - 10.9.0.200 # Points to unbound
+      - 10.9.0.200  # Points to unbound
     environment:
-      WEBPASSWORD: "" # Blank password - Can be whatever you want.
-      ServerIP: 10.1.0.100 # Internal IP of pihole
-      DNS1: 10.9.0.200 # Unbound IP
-      DNS2: 10.9.0.200 # If we don't specify two, it will auto pick google.
+      WEBPASSWORD: ""  # Blank password - Can be whatever you want.
+      ServerIP: 10.1.0.100  # Internal IP of pihole
+      DNS1: 10.9.0.200  # Unbound IP
+      DNS2: 10.9.0.200  # If we don't specify two, it will auto pick google.
     volumes:
       - "/var/docker/wirehole/etc-pihole/:/etc/pihole/"
       - "/var/docker/wirehole/etc-dnsmasq.d/:/etc/dnsmasq.d/"
@@ -85,10 +86,10 @@ services:
     #   https://github.com/wirehole-pihole/docker-wirehole-pihole#note-on-capabilities
     cap_add:
       - NET_ADMIN
-    ports: 
-      - 890:80/tcp # pihole Admin GUI 
-      # - 53:53/tcp # Port freigeben, wenn Pihole auch lokal DNS Anfragen verwendet werden soll
-      # - 53:53/udp # Port freigeben, wenn Pihole auch lokal DNS Anfragen verwendet werden soll
+    ports:
+      - 890:80/tcp  # pihole Admin GUI 
+      # - 53:53/tcp  # Port freigeben, wenn Pihole auch lokal DNS Anfragen verwendet werden soll
+      # - 53:53/udp  # Port freigeben, wenn Pihole auch lokal DNS Anfragen verwendet werden soll
     networks:
       private_network:
         ipv4_address: 10.9.0.100

--- a/wirehole/unbound/unbound.conf
+++ b/wirehole/unbound/unbound.conf
@@ -1,0 +1,309 @@
+server:
+    ###########################################################################
+    # BASIC SETTINGS
+    ###########################################################################
+    # Time to live maximum for RRsets and messages in the cache. If the maximum
+    # kicks in, responses to clients still get decrementing TTLs based on the
+    # original (larger) values. When the internal TTL expires, the cache item
+    # has expired. Can be set lower to force the resolver to query for data
+    # often, and not trust (very large) TTL values.
+    cache-max-ttl: 86400
+
+    # Time to live minimum for RRsets and messages in the cache. If the minimum
+    # kicks in, the data is cached for longer than the domain owner intended,
+    # and thus less queries are made to look up the data. Zero makes sure the
+    # data in the cache is as the domain owner intended, higher values,
+    # especially more than an hour or so, can lead to trouble as the data in
+    # the cache does not match up with the actual data any more.
+    cache-min-ttl: 60
+
+    # Set the working directory for the program.
+    directory: "/opt/unbound/etc/unbound"
+
+    # RFC 6891. Number of bytes size to advertise as the EDNS reassembly buffer
+    # size. This is the value put into datagrams over UDP towards peers.
+    # 4096 is RFC recommended. 1472 has a reasonable chance to fit within a
+    # single Ethernet frame, thus lessing the chance of fragmentation
+    # reassembly problems (usually seen as timeouts). Setting to 512 bypasses
+    # even the most stringent path MTU problems, but is not recommended since
+    # the amount of TCP fallback generated is excessive.
+    edns-buffer-size: 1472
+
+    # Listen to for queries from clients and answer from this network interface
+    # and port.
+    interface: 0.0.0.0@53
+
+    # Rotates RRSet order in response (the pseudo-random number is taken from
+    # the query ID, for speed and thread safety).
+    rrset-roundrobin: yes
+
+    # Drop user  privileges after  binding the port.
+    username: "_unbound"
+
+    ###########################################################################
+    # LOGGING
+    ###########################################################################
+
+    # Do not print log lines to inform about local zone actions
+    log-local-actions: no
+
+    # Do not print one line per query to the log
+    log-queries: no
+
+    # Do not print one line per reply to the log
+    log-replies: no
+
+    # Do not print log lines that say why queries return SERVFAIL to clients
+    log-servfail: no
+
+    # Further limit logging
+    logfile: /dev/null
+
+    # Only log errors
+    verbosity: 1
+
+    ###########################################################################
+    # PRIVACY SETTINGS
+    ###########################################################################
+
+    # RFC 8198. Use the DNSSEC NSEC chain to synthesize NXDO-MAIN and other
+    # denials, using information from previous NXDO-MAINs answers. In other
+    # words, use cached NSEC records to generate negative answers within a
+    # range and positive answers from wildcards. This increases performance,
+    # decreases latency and resource utilization on both authoritative and
+    # recursive servers, and increases privacy. Also, it may help increase
+    # resilience to certain DoS attacks in some circumstances.
+    aggressive-nsec: yes
+
+    # Extra delay for timeouted UDP ports before they are closed, in msec.
+    # This prevents very delayed answer packets from the upstream (recursive)
+    # servers from bouncing against closed ports and setting off all sort of
+    # close-port counters, with eg. 1500 msec. When timeouts happen you need
+    # extra sockets, it checks the ID and remote IP of packets, and unwanted
+    # packets are added to the unwanted packet counter.
+    delay-close: 10000
+
+    # Prevent the unbound server from forking into the background as a daemon
+    do-daemonize: no
+
+    # Add localhost to the do-not-query-address list.
+    do-not-query-localhost: no
+
+    # Number  of  bytes size of the aggressive negative cache.
+    neg-cache-size: 4M
+
+    # Send minimum amount of information to upstream servers to enhance
+    # privacy (best privacy).
+    qname-minimisation: yes
+
+    ###########################################################################
+    # SECURITY SETTINGS
+    ###########################################################################
+    # Only give access to recursion clients from LAN IPs
+    access-control: 127.0.0.1/32 allow
+    access-control: 192.168.0.0/16 allow
+    access-control: 172.16.0.0/12 allow
+    access-control: 10.0.0.0/8 allow
+    # access-control: fc00::/7 allow
+    # access-control: ::1/128 allow
+
+    # File with trust anchor for  one  zone, which is tracked with RFC5011
+    # probes.
+    auto-trust-anchor-file: "var/root.key"
+
+    # Enable chroot (i.e, change apparent root directory for the current
+    # running process and its children)
+    chroot: "/opt/unbound/etc/unbound"
+
+    # Deny queries of type ANY with an empty response.
+    #deny-any: yes
+
+    # Harden against algorithm downgrade when multiple algorithms are
+    # advertised in the DS record.
+    harden-algo-downgrade: yes
+
+    # RFC 8020. returns nxdomain to queries for a name below another name that
+    # is already known to be nxdomain.
+    harden-below-nxdomain: yes
+
+    # Require DNSSEC data for trust-anchored zones, if such data is absent, the
+    # zone becomes bogus. If turned off you run the risk of a downgrade attack
+    # that disables security for a zone.
+    harden-dnssec-stripped: yes
+
+    # Only trust glue if it is within the servers authority.
+    harden-glue: yes
+
+    # Ignore very large queries.
+    harden-large-queries: yes
+
+    # Perform additional queries for infrastructure data to harden the referral
+    # path. Validates the replies if trust anchors are configured and the zones
+    # are signed. This enforces DNSSEC validation on nameserver NS sets and the
+    # nameserver addresses that are encountered on the referral path to the
+    # answer. Experimental option.
+    harden-referral-path: no
+
+    # Ignore very small EDNS buffer sizes from queries.
+    harden-short-bufsize: yes
+
+    # Refuse id.server and hostname.bind queries
+    hide-identity: yes
+
+    # Refuse version.server and version.bind queries
+    hide-version: yes
+
+    # Report this identity rather than the hostname of the server.
+    identity: "DNS"
+
+    # These private network addresses are not allowed to be returned for public
+    # internet names. Any  occurrence of such addresses are removed from DNS
+    # answers. Additionally, the DNSSEC validator may mark the  answers  bogus.
+    # This  protects  against DNS  Rebinding
+    private-address: 10.0.0.0/8
+    private-address: 172.16.0.0/12
+    private-address: 192.168.0.0/16
+    private-address: 169.254.0.0/16
+    private-address: fd00::/8
+    private-address: fe80::/10
+    private-address: ::ffff:0:0/96
+
+    # Enable ratelimiting of queries (per second) sent to nameserver for
+    # performing recursion. More queries are turned away with an error
+    # (servfail). This stops recursive floods (e.g., random query names), but
+    # not spoofed reflection floods. Cached responses are not rate limited by
+    # this setting. Experimental option.
+    ratelimit: 1000
+
+    # Use this certificate bundle for authenticating connections made to
+    # outside peers (e.g., auth-zone urls, DNS over TLS connections).
+    tls-cert-bundle: /etc/ssl/certs/ca-certificates.crt
+
+    # Set the total number of unwanted replies to eep track of in every thread.
+    # When it reaches the threshold, a defensive action of clearing the rrset
+    # and message caches is taken, hopefully flushing away any poison.
+    # Unbound suggests a value of 10 million.
+    unwanted-reply-threshold: 10000
+
+    # Use 0x20-encoded random bits in the query to foil spoof attempts. This
+    # perturbs the lowercase and uppercase of query names sent to authority
+    # servers and checks if the reply still has the correct casing.
+    # This feature is an experimental implementation of draft dns-0x20.
+    # Experimental option.
+    use-caps-for-id: yes
+
+    # Help protect users that rely on this validator for authentication from
+    # potentially bad data in the additional section. Instruct the validator to
+    # remove data from the additional section of secure messages that are not
+    # signed properly. Messages that are insecure, bogus, indeterminate or
+    # unchecked are not affected.
+    val-clean-additional: yes
+
+    ###########################################################################
+    # PERFORMANCE SETTINGS
+    ###########################################################################
+    # https://nlnetlabs.nl/documentation/unbound/howto-optimise/
+    # https://nlnetlabs.nl/news/2019/Feb/05/unbound-1.9.0-released/
+
+    # Number of slabs in the infrastructure cache. Slabs reduce lock contention
+    # by threads. Must be set to a power of 2.
+    # infra-cache-slabs: 4
+
+    # Number of incoming TCP buffers to allocate per thread. Default
+    # is 10. If set to 0, or if do-tcp is "no", no  TCP  queries  from
+    # clients  are  accepted. For larger installations increasing this
+    # value is a good idea.
+    # incoming-num-tcp: 10
+
+    # Number of slabs in the key cache. Slabs reduce lock contention by
+    # threads. Must be set to a power of 2. Setting (close) to the number
+    # of cpus is a reasonable guess.
+    # key-cache-slabs: 4
+
+    # Number  of  bytes  size  of  the  message  cache.
+    # Unbound recommendation is to Use roughly twice as much rrset cache memory
+    # as you use msg cache memory.
+    msg-cache-size: 260991658
+
+    # Number of slabs in the message cache. Slabs reduce lock contention by
+    # threads. Must be set to a power of 2. Setting (close) to the number of
+    # cpus is a reasonable guess.
+    #msg-cache-slabs: 4
+
+    # The number of queries that every thread will service simultaneously. If
+    # more queries arrive that need servicing, and no queries can be jostled
+    # out (see jostle-timeout), then the queries are dropped.
+    # This is best set at half the number of the outgoing-range.
+    # This Unbound instance was compiled with libevent so it can efficiently
+    # use more than 1024 file descriptors.
+    num-queries-per-thread: 4096
+
+    # The number of threads to create to serve clients.
+    # This is set dynamically at run time to effectively use available CPUs
+    # resources
+    num-threads: 3
+
+    # Number of ports to open. This number of file descriptors can be opened
+    # per thread.
+    # This Unbound instance was compiled with libevent so it can efficiently
+    # use more than 1024 file descriptors.
+    outgoing-range: 8192
+
+    # Number of bytes size of the RRset cache.
+    # Use roughly twice as much rrset cache memory as msg cache memory
+    rrset-cache-size: 260991658
+
+    # Number of slabs in the RRset cache. Slabs reduce lock contention by
+    # threads. Must be set to a power of 2.
+    #rrset-cache-slabs: 4
+
+    # Do no insert authority/additional sections into response messages when
+    # those sections are not required. This reduces response size
+    # significantly, and may avoid TCP fallback for some responses. This may
+    # cause a slight speedup.
+    minimal-responses: yes
+
+    # # Fetch the DNSKEYs earlier in the validation process, when a DS record
+    # is encountered. This lowers the latency of requests at the expense of
+    # little more CPU usage.
+    prefetch: yes
+
+    # Fetch the DNSKEYs earlier in the validation process, when a DS record is
+    # encountered. This lowers the latency of requests at the expense of little
+    # more CPU usage.
+    prefetch-key: yes
+
+    # Have unbound attempt to serve old responses from cache with a TTL of 0 in
+    # the response without waiting for the actual resolution to finish. The
+    # actual resolution answer ends up in the cache later on.
+    serve-expired: yes
+
+    # Open dedicated listening sockets for incoming queries for each thread and
+    # try to set the SO_REUSEPORT socket option on each socket. May distribute
+    # incoming queries to threads more evenly.
+    so-reuseport: yes
+
+    ###########################################################################
+    # LOCAL ZONE
+    ###########################################################################
+
+    # # Include file for local-data and local-data-ptr
+    # include: /opt/unbound/etc/unbound/a-records.conf
+    # include: /opt/unbound/etc/unbound/srv-records.conf
+
+    # ###########################################################################
+    # # FORWARD ZONE
+    # ###########################################################################
+
+    # include: /opt/unbound/etc/unbound/forward-records.conf
+    
+    forward-zone:
+        name: "."
+        forward-addr: 1.1.1.1@853#cloudflare-dns.com
+        forward-addr: 1.0.0.1@853#cloudflare-dns.com
+        forward-addr: 2606:4700:4700::1111@853#cloudflare-dns.com
+        forward-addr: 2606:4700:4700::1001@853#cloudflare-dns.com
+        forward-tls-upstream: yes
+
+    remote-control:
+        control-enable: no

--- a/wordpress/docker-compose.fpm.yaml
+++ b/wordpress/docker-compose.fpm.yaml
@@ -50,11 +50,7 @@ services:
       - wordpress-app
     labels:
       - "traefik.enable=true"
-      - "traefik.http.middlewares.wordpress-https.redirectscheme.scheme=https"
-      - "traefik.http.routers.wordpress-http.entrypoints=web"
-      - "traefik.http.routers.wordpress-http.rule=Host(`${WORDPRESS_URL}`)"
-      - "traefik.http.routers.wordpress-http.middlewares=wordpress-https@docker"
-      - "traefik.http.routers.wordpress.entrypoints=web-secure"
+      - "traefik.http.routers.wordpress.entrypoints=websecure"
       - "traefik.http.routers.wordpress.rule=Host(`${WORDPRESS_URL}`)"
       - "traefik.http.routers.wordpress.tls=true"
       - "traefik.http.routers.wordpress.tls.certresolver=default"

--- a/wordpress/docker-compose.yaml
+++ b/wordpress/docker-compose.yaml
@@ -32,11 +32,7 @@ services:
       - WORDPRESS_DB_NAME=wordpress
     labels:
       - "traefik.enable=true"
-      - "traefik.http.middlewares.wordpress-https.redirectscheme.scheme=https"
-      - "traefik.http.routers.wordpress-http.entrypoints=web"
-      - "traefik.http.routers.wordpress-http.rule=Host(`wordpress.example.com`)"  # Domain anpassen
-      - "traefik.http.routers.wordpress-http.middlewares=wordpress-https@docker"
-      - "traefik.http.routers.wordpress.entrypoints=web-secure"
+      - "traefik.http.routers.wordpress.entrypoints=websecure"
       - "traefik.http.routers.wordpress.rule=Host(`wordpress.example.com`)"  # Domain anpassen
       - "traefik.http.routers.wordpress.tls=true"
       - "traefik.http.routers.wordpress.tls.certresolver=default"


### PR DESCRIPTION
Anpassungen an den Entrypoints vorgenommen, und eine globale http zu https Weiterleitung in der traefik.toml konfiguriert.

💡 **es wurde auch der Entrypoints *web-secure* in *websecure* umbenannt** 💡 

Quelle: https://doc.traefik.io/traefik/routing/entrypoints/#redirection