### PR TITLE
Verlinkung zu GitHub für Software im Inhaltsverzeichnis

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,66 +26,66 @@ Im Laufe der Zeit können sich Produkte ändern oder nicht mehr durch die Entwic
 # Inhaltsverzeichnis
 
 ## Analyse und Reporting
-* Matomo ([Link 🔗](https://matomo.org) | [Video 📹](https://www.youtube.com/watch?v=dXPO5iWUTSg))
+* [Matomo](https://github.com/cbirkenbeul/docker-homelab/tree/master/analyse-und-reporting/matomo) ([Link 🔗](https://matomo.org) | [Video 📹](https://www.youtube.com/watch?v=dXPO5iWUTSg))
 
 ## Blogs und Webseiten
-* Wordpress ([Link 🔗](https://de.wordpress.org))
+* [Wordpress](https://github.com/cbirkenbeul/docker-homelab/tree/master/blogs-und-webseiten/wordpress) ([Link 🔗](https://de.wordpress.org))
 
 ## Collaboration
-* Nextcloud ([Link 🔗](https://nextcloud.com))
+* [Nextcloud](https://github.com/cbirkenbeul/docker-homelab/tree/master/collaboration/nextcloud) ([Link 🔗](https://nextcloud.com))
 
 ## Dashboard
-* Heimdall ([Link 🔗](https://heimdall.site) | [Video 📹](https://www.youtube.com/watch?v=Dmw7nAEizWk))
+* [Heimdall](https://github.com/cbirkenbeul/docker-homelab/tree/master/Dashboard/heimdall) ([Link 🔗](https://heimdall.site) | [Video 📹](https://www.youtube.com/watch?v=Dmw7nAEizWk))
 
 ## Datenbanken
-* influxdb ([Link 🔗](https://www.influxdata.com/products/influxdb/))
+* [influxdb](https://github.com/cbirkenbeul/docker-homelab/tree/master/datenbanken/influxdb) ([Link 🔗](https://www.influxdata.com/products/influxdb/))
 
 ## Docker
-* Portainer ([Link 🔗](https://www.portainer.io))
-* Watchtower ([Link 🔗](https://github.com/containrrr/watchtower))
+* [Portainer](https://github.com/cbirkenbeul/docker-homelab/tree/master/docker/portainer) ([Link 🔗](https://www.portainer.io))
+* [Watchtower](https://github.com/cbirkenbeul/docker-homelab/tree/master/docker/watchtower) ([Link 🔗](https://github.com/containrrr/watchtower))
 
 ## Medien und Medienmanagement
-* Calibre (incl. Calibre-Web) ([Link 🔗](https://calibre-ebook.com))
-* PLEX Medien Server ([Link 🔗](https://www.plex.tv))
-* Tautulli ([Link 🔗](https://tautulli.com))
+* [Calibre (incl. Calibre-Web)](https://github.com/cbirkenbeul/docker-homelab/tree/master/medien-und-medienmanagement/calibre)) ([Link 🔗](https://calibre-ebook.com))
+* [PLEX Medien Server](https://github.com/cbirkenbeul/docker-homelab/tree/master/medien-und-medienmanagement/plex) ([Link 🔗](https://www.plex.tv))
+* [Tautulli](https://github.com/cbirkenbeul/docker-homelab/tree/master/medien-und-medienmanagement/tautulli) ([Link 🔗](https://tautulli.com))
 
 ## Netzwerktools
-* Adguard Home ([Link 🔗](https://adguard.com/de/adguard-home/overview.html))
-* apt-cacher-ng ([Link 🔗](https://wiki.debian.org/AptCacherNg) | [Video 📹](https://www.youtube.com/watch?v=YwkfYaAeDh8))
-* Cloudflare-ddns
-* NTP Server
-* phpIPAM ([Link 🔗](https://phpipam.net) | [Video 📹](https://www.youtube.com/watch?v=oUAkkJJS_AY))
-* Pi-hole ([Link 🔗](https://pi-hole.net))
-* WireHole ([Link 🔗](https://github.com/IAmStoxe/wirehole))
+* [Adguard Home](https://github.com/cbirkenbeul/docker-homelab/tree/master/netzwerktools/adguard-home) ([Link 🔗](https://adguard.com/de/adguard-home/overview.html))
+* [apt-cacher-ng](https://github.com/cbirkenbeul/docker-homelab/tree/master/netzwerktools/apt-cacher-ng) ([Link 🔗](https://wiki.debian.org/AptCacherNg) | [Video 📹](https://www.youtube.com/watch?v=YwkfYaAeDh8))
+* [Cloudflare-ddns](https://github.com/cbirkenbeul/docker-homelab/tree/master/netzwerktools/cloudflare-ddns) 
+* [NTP Server](https://github.com/cbirkenbeul/docker-homelab/tree/master/netzwerktools/ntp-server) ([Link 🔗](https://github.com/cturra/docker-ntp))
+* [phpIPAM](https://github.com/cbirkenbeul/docker-homelab/tree/master/netzwerktools/phpipam) ([Link 🔗](https://phpipam.net) | [Video 📹](https://www.youtube.com/watch?v=oUAkkJJS_AY))
+* [Pi-hole](https://github.com/cbirkenbeul/docker-homelab/tree/master/netzwerktools/pi-hole) ([Link 🔗](https://pi-hole.net))
+* [WireHole](https://github.com/cbirkenbeul/docker-homelab/tree/master/netzwerktools/wirehole) ([Link 🔗](https://github.com/IAmStoxe/wirehole))
 
 ## News und RSS
-* FreshRSS ([Link 🔗](https://freshrss.org) | [Video 📹](https://www.youtube.com/watch?v=0r7vf2MXQYU))
-* Miniflux ([Link 🔗](https://miniflux.app))
+* [FreshRSS](https://github.com/cbirkenbeul/docker-homelab/tree/master/news-und-rss/freshrss) ([Link 🔗](https://freshrss.org) | [Video 📹](https://www.youtube.com/watch?v=0r7vf2MXQYU))
+* [Miniflux](https://github.com/cbirkenbeul/docker-homelab/tree/master/news-und-rss/miniflux) ([Link 🔗](https://miniflux.app))
 
 ## Passwort Manager
-* Bitwarden_rs ([Link 🔗](https://github.com/dani-garcia/bitwarden_rs))
+* [Bitwarden_rs](https://github.com/cbirkenbeul/docker-homelab/tree/master/password-manager/bitwarden_rs) ([Link 🔗](https://github.com/dani-garcia/bitwarden_rs))
 
 ## Programmierung und Code-Verwaltung
-* Drone.io ([Link 🔗](https://drone.io))
-* Gitea ([Link 🔗](https://gitea.io) | [Video 📹](https://www.youtube.com/watch?v=2h-gkICAcbk))
+* [Drone.io](https://github.com/cbirkenbeul/docker-homelab/tree/master/programmierung-und-code-verwaltung/droneio) ([Link 🔗](https://drone.io))
+* [Gitea](https://github.com/cbirkenbeul/docker-homelab/tree/master/programmierung-und-code-verwaltung/gitea) ([Link 🔗](https://gitea.io) | [Video 📹](https://www.youtube.com/watch?v=2h-gkICAcbk))
 
 ## Remotemanagement
-* Guacamole ([Link 🔗](http://guacamole.apache.org) | [Video 📹](https://www.youtube.com/watch?v=vMhjvGLeHrY))
+* [Guacamole](https://github.com/cbirkenbeul/docker-homelab/tree/master/remotemanagement/guacamole) ([Link 🔗](http://guacamole.apache.org) | [Video 📹](https://www.youtube.com/watch?v=vMhjvGLeHrY))
 
 ## Reverse Proxys und SSL
-* Traefik ([Link 🔗](https://traefik.io))
+* [Traefik](https://github.com/cbirkenbeul/docker-homelab/tree/master/reverse-proxy-und-ssl/traefik) ([Link 🔗](https://traefik.io))
 
 ## Sonstiges
-* ilias ([Link 🔗](https://www.ilias.de))
-* Monitoring (Node Exporter, Prometheus, cAdvisor, Grafana)
-* Recipes ([Link 🔗](https://github.com/vabene1111/recipes))
-* Statping ([Link 🔗](https://demo.statping.com))
-* Wallabag ([Link 🔗](https://www.wallabag.it/de/))
+* [ilias](https://github.com/cbirkenbeul/docker-homelab/tree/master/sonstiges/ilias) ([Link 🔗](https://www.ilias.de))
+* [Monitoring (Node Exporter, Prometheus, cAdvisor, Grafana)](https://github.com/cbirkenbeul/docker-homelab/tree/master/sonstiges/monitoring)
+* [Recipes](https://github.com/cbirkenbeul/docker-homelab/tree/master/sonstiges/recipes) ([Link 🔗](https://github.com/vabene1111/recipes))
+* [Statping](https://github.com/cbirkenbeul/docker-homelab/tree/master/sonstiges/statping) ([Link 🔗](https://demo.statping.com))
+* [Wallabag](https://github.com/cbirkenbeul/docker-homelab/tree/master/sonstiges/wallabag) ([Link 🔗](https://www.wallabag.it/de/))
 
 ## Ticketsysteme
-* FreeScout ([Link 🔗](https://freescout.net/) | [Video 📹](https://www.youtube.com/watch?v=OgKFAlunEL4))
-* Redmine ([Link 🔗](https://www.redmine.org))
+* [FreeScout](https://github.com/cbirkenbeul/docker-homelab/tree/master/ticketsysteme/freescout) ([Link 🔗](https://freescout.net/) | [Video 📹](https://www.youtube.com/watch?v=OgKFAlunEL4))
+* [Redmine](https://github.com/cbirkenbeul/docker-homelab/tree/master/ticketsysteme/redmine) ([Link 🔗](https://www.redmine.org))
 
 ## Wikis
-* Bookstack ([Link 🔗](https://www.bookstackapp.com) | [Video 📹](https://www.youtube.com/watch?v=FarZzeePgds))
-* Wiki.js ([Link 🔗](https://wiki.js.org))
+* [Bookstack](https://github.com/cbirkenbeul/docker-homelab/tree/master/wiki/bookstack) ([Link 🔗](https://www.bookstackapp.com) | [Video 📹](https://www.youtube.com/watch?v=FarZzeePgds))
+* [Wiki.js](https://github.com/cbirkenbeul/docker-homelab/tree/master/wiki/wiki-js) ([Link 🔗](https://wiki.js.org))


### PR DESCRIPTION
Links zu der Docker Software im Inhaltsverzeichnis hinzugefügt, welche zu der jeweiligen GitHub Seite mit der Docker-Compose leiten.

Hat den Vorteil, das wenn ich als neuer Nutzer mir die Readme anschaue und ich eine interesannte Software finde, die Verlinkung mich direkt dahin bringt.

Beispiel: Ich möchte zu Tautulli, gehe also zur Ordner Übersicht und finde dieses erst nicht. Erst auf dem zweiten Blick merke ich, das dieses sich in Medien und Medienmanagement versteckt. Mit der Verlinkung dahin kann dieses Problem vorgebeugt werden.

Ist sicher Meinungssache. 