### PR TITLE
Beschreibung hinzugefügt über Attachment fix beim bitwarden_rs Container

### DIFF
--- a/password-manager/bitwarden_rs/README.md
+++ b/password-manager/bitwarden_rs/README.md
@@ -4,3 +4,8 @@ Daher besteht dieser Service nur aus einem Container und nicht auf einer vielzah
 
 # WICHTIG!
 Wenn ihr Probleme mit Bitwarden habt, bitte nicht im offiziellen Forum posten, sondern direkt beim [Entwickler](https://github.com/dani-garcia/bitwarden_rs)
+
+# Attachments herunterladen
+Mit der Standardkonfiguration kann man Attachments zwar hochladen & löschen, nicht aber herunterladen.
+Nachdem der Container das erste Mal gestartet wurde, sollte eine Konfigurationsdatei `config.json` im `/var/docker/bitwarden` Verzeichnis liegen.
+Diese muss mit *root* Rechten bearbeitet und der Eintrag `domain: http://localhost` durch die gewünschte domain erstetzt werden (z.B. `https://bitwarden.example.com`).


### PR DESCRIPTION
Ich habe diesen Fix heute bei meinem bitwarden_rs container angewendet und kann nun die Attachments auch herunterladen.

Ich habe kurz überlegt ob man es automatisiert machen kann (z.B. mit einem sed Command) aber nachdem dann jede:r Pfad und URL selbst bearbeiten müsste, glaube ich es macht keinen Sinn. (und ich war faul) 

#76 