### PR TITLE
ssllabs.com von Rating B auf Rating A+

### DIFF
--- a/reverse-proxy-und-ssl/traefik/config/dynamic.yml
+++ b/reverse-proxy-und-ssl/traefik/config/dynamic.yml
@@ -3,17 +3,19 @@ tls:
   options:
     default:
       minVersion: VersionTLS12
+      sniStrict : true
       cipherSuites:
         - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
         - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
-        - TLS_AES_128_GCM_SHA256
-        - TLS_AES_256_GCM_SHA384
-        - TLS_CHACHA20_POLY1305_SHA256
-    curvePreferences:
-      - CurveP521
-      - CurveP384
-    sniStrict: true
+        - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+        - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+        - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+      curvePreferences:
+        - CurveP521
+        - CurveP384        
+    mintls13:
+      minVersion: VersionTLS13
 
 http:
   middlewares:


### PR DESCRIPTION
Bei dem Test der docker-homelab Domain über https://www.ssllabs.com/ssltest habe ich festgestellt, dass ich ein Rating B erhalte. Obwohl in der dynamic.yml bereits `minVersion: VersionTLS12` konfiguriert ist, wurden TLS 1.1 und TLS 1.0 unterstützt.

Nach dieser Anpassung erhalte ich ein Rating von 'A+'