### PR TITLE
Adding DB Envs to NextCloud Containers

### DIFF
--- a/compose-files-traefik-predefined/nextcloud/docker-compose.yaml
+++ b/compose-files-traefik-predefined/nextcloud/docker-compose.yaml
@@ -37,6 +37,10 @@ services:
     environment:
       - REDIS_HOST=nextcloud-redis
       - REDIS_HOST_PASSWORD=${REDIS_PASSWORD}
+      - MYSQL_DATABASE=${MYSQL_DATABASE}
+      - MYSQL_USER=${MYSQL_USER}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+      - MYSQL_HOST=nextcloud-db
     volumes:
       - /var/docker/nextcloud/app:/var/www/html
       # - EXTERNES DATENVERZEICHNIS:/var/www/html/data

--- a/compose-files-traefik-predefined/nextcloud/docker-compose_rpi-nextcloud.yaml
+++ b/compose-files-traefik-predefined/nextcloud/docker-compose_rpi-nextcloud.yaml
@@ -40,6 +40,11 @@ services:
     networks:
       - traefik_proxy
       - default
+    entrypoint: 
+      - MYSQL_DATABASE=${MYSQL_DATABASE}
+      - MYSQL_USER=${MYSQL_USER}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+      - MYSQL_HOST=nextcloud-db
 
 networks:
   traefik_proxy:


### PR DESCRIPTION
Add DB Envs to NextCloud Containers so you don't have to enter them during installation. 